### PR TITLE
File Input (1 of 2)

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@near-pagoda/ui",
-  "version": "0.2.6",
+  "version": "0.2.7",
   "description": "A React component library that implements the official NEAR design system.",
   "license": "MIT",
   "repository": {

--- a/src/components/FileInput.README.md
+++ b/src/components/FileInput.README.md
@@ -1,5 +1,9 @@
 # FileInput
 
+This component uses a native `<input type="file" />` tag underneath the hood. The [accept](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/accept) and [multiple](https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/multiple) props are passed through to the input tag and behave as they would natively. We've included client side validation to make sure the `accept` and `multiple` props are respected for both selected and dropped files.
+
+Additionally, you can pass a value for `maxFileSizeBytes` to limit the max size of each file. The default is unlimited (undefined).
+
 ```tsx
 import { FileInput } from '@near-pagoda/ui';
 
@@ -16,11 +20,11 @@ const [disabled, setDisabled] = useState(false);
   accept="image/*"
   error={error}
   disabled={disabled}
+  maxFileSizeBytes={1_000_000}
   multiple
-  onChange={(fileList) => console.log(fileList)}
+  onChange={(files) => console.log(files)}
 />
 ```
-
 
 ## React Hook Form
 
@@ -29,7 +33,7 @@ import { FileInput } from '@near-pagoda/ui';
 import { Controller, useForm } from 'react-hook-form';
 
 type FormSchema = {
-  artwork: FileList;
+  artwork: File[];
 };
 
 ...

--- a/src/components/FileInput.README.md
+++ b/src/components/FileInput.README.md
@@ -1,0 +1,52 @@
+# FileInput
+
+```tsx
+import { FileInput } from '@near-pagoda/ui';
+
+...
+
+const [error, setError] = useState("");
+const [disabled, setDisabled] = useState(false);
+
+...
+
+<FileInput
+  label="Artwork"
+  name="artwork"
+  accept="image/*"
+  error={error}
+  disabled={disabled}
+  multiple
+  onChange={(fileList) => console.log(fileList)}
+/>
+```
+
+
+## React Hook Form
+
+```tsx
+import { FileInput } from '@near-pagoda/ui';
+import { Controller, useForm } from 'react-hook-form';
+
+type FormSchema = {
+  artwork: FileList;
+};
+
+...
+
+
+const form = useForm<FormSchema>();
+
+...
+
+<Controller
+  control={form.control}
+  name="artwork"
+  rules={{
+    required: 'Please select an image',
+  }}
+  render={({ field, fieldState }) => (
+    <FileInput label="Event Artwork" accept="image/*" error={fieldState.error?.message} {...field} />
+  )}
+/>
+```

--- a/src/components/FileInput.module.scss
+++ b/src/components/FileInput.module.scss
@@ -1,0 +1,92 @@
+.wrapper {
+  display: flex;
+  width: 100%;
+  flex-direction: column;
+  gap: 5px;
+
+  &:focus-within .input {
+    border-style: solid;
+    border-color: var(--violet8);
+  }
+}
+
+.label {
+  display: block;
+  font: var(--text-xs);
+  font-weight: 600;
+  color: var(--sand12);
+}
+
+.nativeInput {
+  opacity: 0;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+}
+
+.input {
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+  gap: var(--gap-m);
+  padding: var(--gap-m);
+  border-radius: 6px;
+  background-color: var(--white);
+  border: 2px dashed var(--sand6);
+  outline: none;
+  transition: all var(--transition-speed);
+  cursor: pointer;
+
+  [data-disabled='true'] & {
+    pointer-events: none;
+    opacity: 0.5;
+  }
+
+  [data-dragging='true'] & {
+    border-color: var(--violet8);
+  }
+
+  [data-error='true'] & {
+    border-color: var(--red9);
+  }
+
+  &:hover {
+    border-style: solid;
+    background: var(--sand2);
+  }
+}
+
+.files {
+  display: flex;
+  align-items: stretch;
+  flex-direction: column;
+  gap: var(--gap-m);
+}
+
+.file {
+  display: flex;
+  flex-direction: column;
+  gap: var(--gap-xs);
+  padding-bottom: var(--gap-m);
+  border-bottom: 1px solid var(--sand6);
+
+  img {
+    display: block;
+    max-width: 100%;
+    border-radius: 4px;
+  }
+}
+
+.filename {
+  width: 100%;
+  display: flex;
+  align-items: center;
+  gap: var(--gap-s);
+}
+
+.cta {
+  display: flex;
+  align-items: center;
+  flex-direction: column;
+  gap: var(--gap-s);
+}

--- a/src/components/FileInput.tsx
+++ b/src/components/FileInput.tsx
@@ -1,0 +1,105 @@
+import { FileArrowUp, Paperclip } from '@phosphor-icons/react';
+import type { ChangeEventHandler, ComponentProps, CSSProperties, DragEventHandler, FocusEventHandler } from 'react';
+import { forwardRef, useState } from 'react';
+
+import { useDebouncedValue } from '../hooks/debounce';
+import { AssistiveText } from './AssistiveText';
+import s from './FileInput.module.scss';
+import { SvgIcon } from './SvgIcon';
+import { Text } from './Text';
+
+type Props = {
+  accept: ComponentProps<'input'>['accept'];
+  className?: string;
+  disabled?: boolean;
+  error?: string;
+  label?: string;
+  multiple?: boolean;
+  name: string;
+  onBlur?: FocusEventHandler<HTMLInputElement>;
+  onChange: (value: FileList | null) => any;
+  style?: CSSProperties;
+  value?: FileList | null | undefined;
+};
+
+export const FileInput = forwardRef<HTMLInputElement, Props>(
+  ({ className = '', disabled, label, error, style, name, value, ...props }, ref) => {
+    const [isDragging, setIsDragging] = useState(false);
+    const isDraggingDebounced = useDebouncedValue(isDragging, 50);
+    const files = [...(value ?? [])];
+    const assistiveTextId = `${name}-assistive-text`;
+
+    const onChange: ChangeEventHandler<HTMLInputElement> = (event) => {
+      props.onChange(event.target.files);
+    };
+
+    const onDragLeave: DragEventHandler<HTMLLabelElement> = () => {
+      setIsDragging(false);
+    };
+
+    const onDragOver: DragEventHandler<HTMLLabelElement> = (event) => {
+      event.preventDefault();
+      setIsDragging(true);
+    };
+
+    const onDrop: DragEventHandler<HTMLLabelElement> = async (event) => {
+      event.preventDefault();
+      setIsDragging(false);
+      props.onChange(event.dataTransfer.files);
+    };
+
+    return (
+      <label
+        className={`${s.wrapper} ${className}`}
+        style={style}
+        data-dragging={isDraggingDebounced}
+        data-disabled={disabled}
+        data-error={!!error}
+        onDragLeave={onDragLeave}
+        onDragOver={onDragOver}
+        onDrop={onDrop}
+      >
+        <input
+          type="file"
+          className={s.nativeInput}
+          aria-errormessage={error ? assistiveTextId : undefined}
+          aria-invalid={!!error}
+          ref={ref}
+          name={name}
+          disabled={disabled}
+          {...props}
+          onChange={onChange}
+          value={undefined}
+        />
+
+        {label && <span className={s.label}>{label}</span>}
+
+        <div className={s.input}>
+          {files.length > 0 && (
+            <div className={s.files}>
+              {files.map((file) => (
+                <div className={s.file} key={file.name}>
+                  {file.type.includes('image/') && <img src={URL.createObjectURL(file)} alt={file.name} />}
+
+                  <div className={s.filename}>
+                    <SvgIcon icon={<Paperclip />} size="xs" color="sand10" />
+                    <Text size="text-xs">{file.name}</Text>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className={s.cta}>
+            <SvgIcon icon={<FileArrowUp />} color="violet8" />
+            <Text size="text-s">Select or drag & drop {props.multiple ? 'files' : 'file'}</Text>
+          </div>
+        </div>
+
+        <AssistiveText variant="error" message={error} id={assistiveTextId} />
+      </label>
+    );
+  },
+);
+
+FileInput.displayName = 'FileInput';

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,6 +10,7 @@ export * from './components/Combobox';
 export * from './components/Container';
 export * as Dialog from './components/Dialog';
 export * as Dropdown from './components/Dropdown';
+export * from './components/FileInput';
 export * from './components/Flex';
 export * from './components/Form';
 export * from './components/Grid';

--- a/src/utils/number.ts
+++ b/src/utils/number.ts
@@ -24,3 +24,15 @@ export function formatDollar(number: string | number | null | undefined) {
 
   return dollarFormatter.format(parsedNumber);
 }
+
+export function formatBytes(bytes: number | null | undefined, decimals = 1) {
+  if (!bytes) return '0 Bytes';
+
+  const k = 1000;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return `${parseFloat((bytes / Math.pow(k, i)).toFixed(dm))} ${sizes[i]}`;
+}


### PR DESCRIPTION
Closes: https://github.com/near/pagoda-ui/issues/1

Unfortunately, we don't currently have a great way of previewing this new component. We have a ticket open to build out a component preview page that should help with this in the future: https://github.com/near/pagoda-ui/issues/6

- Implement new `FileInput` component
- Supports drag and drop
- Support single vs multiple file selection via `multiple` boolean prop and limit file types via `accept` prop
- Validate all files based on `accept`, `multiple`, and `maxFileSizeBytes`
- Works well with React Hook Form

Feel free to check out the code and new README file and let me know if you have any suggestions! Once this is merged and published, I'll push another PR to update our ticketing project to use this new component on our `/events/new` route.

Here are some screenshots:

<img width="586" alt="Screenshot 2024-08-06 at 3 27 18 PM" src="https://github.com/user-attachments/assets/eef6a9fd-feb3-4725-9247-43f0e54c9d11">
<img width="551" alt="Screenshot 2024-08-06 at 3 27 36 PM" src="https://github.com/user-attachments/assets/d6f65b3b-b752-4f85-a615-a0ee4185718e">
<img width="562" alt="Screenshot 2024-08-06 at 3 28 00 PM" src="https://github.com/user-attachments/assets/ddcd7536-6b56-49cc-bd43-d4506b5c50b2">
